### PR TITLE
Ping

### DIFF
--- a/src/gvpn_controller.py
+++ b/src/gvpn_controller.py
@@ -100,7 +100,7 @@ class GvpnUdpServer(UdpServer):
     def serve(self):
         socks, _, _ = select.select(self.sock_list, [], [], CONFIG["wait_time"])
         for sock in socks:
-            if sock == self.sock:
+            if sock == self.sock or sock == self.sock_svr:
                 #---------------------------------------------------------------
                 #| offset(byte) |                                              |
                 #---------------------------------------------------------------
@@ -118,6 +118,10 @@ class GvpnUdpServer(UdpServer):
                     msg = json.loads(data[2:])
                     logging.debug("recv %s %s" % (addr, data[2:]))
                     msg_type = msg.get("type", None)
+                    if msg_type == "echo_request":
+                        make_remote_call(self.sock_svr, m_type=tincan_control,\
+                          dest_addr=addr[0], dest_port=addr[1], payload=None,\ 
+                          msg_type="echo_reply")
                     if msg_type == "local_state":
                         self.state = msg
                     elif msg_type == "peer_state": 

--- a/src/ipoplib.py
+++ b/src/ipoplib.py
@@ -28,6 +28,7 @@ CONFIG = {
     "ip6_mask": 64,
     "subnet_mask": 32,
     "svpn_port": 5800,
+    "contr_port": 5801,
     "local_uid": "",
     "uid_size": 40,
     "sec": True,
@@ -231,10 +232,14 @@ class UdpServer(object):
         self.conn_stat = {}
         if socket.has_ipv6:
             self.sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+            self.sock_svr = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+            self.sock_svr.bind((CONFIG["localhost6"], CONFIG["contr_port"]))
         else:
             self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            self.sock_svr = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            self.sock_svr.bind((CONFIG["localhost"], CONFIG["contr_port"]))
         self.sock.bind(("", 0))
-        self.sock_list = [ self.sock ]
+        self.sock_list = [ self.sock, self.sock_svr ]
 
     def inter_controller_conn(self):
 

--- a/src/svpn_controller.py
+++ b/src/svpn_controller.py
@@ -34,7 +34,7 @@ class SvpnUdpServer(UdpServer):
     def serve(self):
         socks, _, _ = select.select(self.sock_list, [], [], CONFIG["wait_time"])
         for sock in socks:
-            if sock == self.sock:
+            if sock == self.sock or sock == self.sock_svr:
                 data, addr = sock.recvfrom(CONFIG["buf_size"])
                 #---------------------------------------------------------------
                 #| offset(byte) |                                              |
@@ -52,7 +52,10 @@ class SvpnUdpServer(UdpServer):
                     msg = json.loads(data[2:])
                     logging.debug("recv %s %s" % (addr, data[2:]))
                     msg_type = msg.get("type", None)
-    
+                    if msg_type == "echo_request":
+                        make_remote_call(self.sock_svr, m_type=tincan_control,\
+                          dest_addr=addr[0], dest_port=addr[1], payload=None,\
+                          msg_type="echo_reply")
                     if msg_type == "local_state":
                         self.state = msg
                     elif msg_type == "peer_state":


### PR DESCRIPTION
echo_request and echo_reply mode is added for windows watchdog for the windows watchdog.
Controller use the port number 5801 for the UDP server. 
If we send {"msg_type" : "echo_request"} to either tincan or controller, it should be reply with {"msg_type": "echo_reply"}
