### PR TITLE
[DEBUG] In switchmode, migration debug

### DIFF
--- a/src/ipoplib.py
+++ b/src/ipoplib.py
@@ -342,6 +342,10 @@ class UdpServer(object):
     def packet_handle(self, data):
         ip4 = ip4_b2a(data[72:76])
         if ip4 in self.arp_table:
+            if self.arp_table[ip4]["local"]:
+                logging.debug("OS arp cache not yet evicted {0}. discarding"
+                              " packet".format(ip4))
+                return
             make_remote_call(self.cc_sock,dest_addr=self.arp_table[ip4]["ip6"],\
               dest_port=CONFIG["icc_port"], m_type=tincan_packet, 
               payload=data[42:])


### PR DESCRIPTION
If migration occurs and associated ip address does not respond in
local, the ip packet is forwarded to controller. IPOP controller
used to try to forward it and made an exception error. Now if
ip packet that used to be local instance is simply discarded and
let local arp request message is produced. Then finally, arp local
 is invalidated through remote arp reply message.
