### PR TITLE
Linux bridge not respond to ARP request

### DIFF
--- a/src/gvpn_controller.py
+++ b/src/gvpn_controller.py
@@ -238,7 +238,7 @@ class GvpnUdpServer(UdpServer):
             elif sock == self.cc_sock:
                 data, addr = sock.recvfrom(CONFIG["buf_size"])
                 logging.debug("ICC packet received from {0}".format(addr))
-                self.icc_packet_handle(data)
+                self.icc_packet_handle(addr, data)
                 
             else:
                 logging.error("Unknown type socket")


### PR DESCRIPTION
The bridge itself does not reply on ARP request that the host
machine of IPOP running cannot receive packet even though it can
send packet to any IPOP and IPOP associated instance. This solution
or work around is IPOP controller provides ARP reply message instead of bridge to
remote peers.
