### PR TITLE
Updates

### DIFF
--- a/controller/framework/CFxHandle.py
+++ b/controller/framework/CFxHandle.py
@@ -90,6 +90,8 @@ class CFxHandle(object):
             else:
                 try:
                     self.CMInstance.processCBT(cbt)
+                except SystemExit:
+                    sys.exit()
                 except:
                     logCBT = self.createCBT(initiator=self.CMInstance.__class__.__name__,
                                                                   recipient='Logger',
@@ -109,6 +111,8 @@ class CFxHandle(object):
             event.wait(interval)
             try:
                 self.CMInstance.timer_method()
+            except SystemExit:
+                sys.exit()
             except:
                 logCBT = self.createCBT(initiator=self.CMInstance.__class__.__name__,
                                                                 recipient='Logger',

--- a/controller/modules/gvpn/TincanDispatcher.py
+++ b/controller/modules/gvpn/TincanDispatcher.py
@@ -1,4 +1,5 @@
 ﻿import json
+import sys
 from controller.framework.ControllerModule import ControllerModule
 import controller.framework.ipoplib as ipoplib
 


### PR DESCRIPTION
[1] TincanDispatcher: fix missing import
For the `sys.exit()` that occurs when there is an IPOP version mismatch in TincanDispatcher.

[2] CFxHandle: insist SystemExit for normal exit calls
Normal exit calls such as `sys.exit()` raise a `SystemExit` exception. The exception handling within CFx catches this exception, so the controller resumes. This commit adds a special handler for the `SystemExit` exception so that normal exits succeed as intended.

**NOTE:** A consequence of [2] is that the `sys.exit()` described in [1] causes a normal exit of the controller.
