### PR TITLE
gvpn: make CentralVisualizer optional in the BaseTopologyManager

### DIFF
--- a/controller/modules/gvpn/BaseTopologyManager.py
+++ b/controller/modules/gvpn/BaseTopologyManager.py
@@ -804,11 +804,13 @@ class BaseTopologyManager(ControllerModule):
             # update local state and peer list
             self.registerCBT('TincanSender', 'DO_GET_STATE', '')
 
-        # every <interval_central_visualizer> seconds
-        if self.interval_counter % self.CMConfig["interval_central_visualizer"] == 0:
-            # send information to central visualizer
-            if self.p2p_state != "started":
-                self.visual_debugger()
+        # send information to the central visualizer, if enabled
+        if self.CMConfig["central_visualizer"]:
+            # every <interval_central_visualizer> seconds
+            if self.interval_counter % self.CMConfig["interval_central_visualizer"] == 0:
+                # send information to central visualizer
+                if self.p2p_state != "started":
+                    self.visual_debugger()
 
     def terminate(self):
         pass

--- a/controller/modules/sample-gvpn-config.json
+++ b/controller/modules/sample-gvpn-config.json
@@ -30,8 +30,9 @@
         "threshold_on_demand": 128,
         "timer_interval": 1,
         "interval_management": 15,
+        "central_visualizer": false,
         "interval_central_visualizer": 5,
-        "dependencies": ["Logger", "CentralVisualizer"]
+        "dependencies": ["Logger"]
     },
         "LinkManager": {
         "dependencies": ["Logger"]


### PR DESCRIPTION
Summary of changes:
- add a flag for BaseTopologyManager in the gvpn-config to enable/disable CentralVisualizer
- add if-then in BaseTopologyManager (if CentralVisualizer is enabled then use it; otherwise, do not)

As a result, the BaseTopologyManager does not depend on the CentralVisualizer