### PR TITLE
Update steps for sudo to prompt for password

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Obtain **IPOP-Tincan** by downloading the latest archive from the releases or by
 
 3. Run IPOP-Tincan.
 
-    ```cd ../..;  sudo ./ipop-tincan &> tin.log &  ```
+    ```cd ../..;  sudo -b ./ipop-tincan &> tin.log ```
 
 4. Run SocialVPN Controller.
 
@@ -48,7 +48,7 @@ Obtain **IPOP-Tincan** by downloading the latest archive from the releases or by
 
 3. Run IPOP-Tincan.
 
-    ```cd ../.. ; sudo ./ipop-tincan &> tin.log &  ```
+    ```cd ../.. ; sudo -b ./ipop-tincan &> tin.log ```
 
 4. Run GroupVPN Controller.
 


### PR DESCRIPTION
Updated step 3 of both configurations to include -b (background flag) for running tincan. This way, the ipop-tincan process is put into background only after asking the password from the user. 
Note that doing this way, doesn't show up the process by running 'jobs' command on terminal. But killing it could be done in the same way as before.