### PR TITLE
Update CentralVisualizer interface

### DIFF
--- a/controller/modules/CentralVisualizer.py
+++ b/controller/modules/CentralVisualizer.py
@@ -27,6 +27,9 @@ class CentralVisualizer(ControllerModule):
 
     def processCBT(self, cbt):
         if(cbt.action == 'SEND_INFO'):
+
+            cbt.data["name"] = self.CMConfig["name"]
+
             message = json.dumps(cbt.data).encode("utf8")
             self.vis_dbg_sock.sendto(message, self.vis_address)
 

--- a/controller/modules/gvpn/BaseTopologyManager.py
+++ b/controller/modules/gvpn/BaseTopologyManager.py
@@ -840,8 +840,7 @@ class BaseTopologyManager(ControllerModule):
         # every <interval_central_visualizer> seconds
         if self.use_visualizer and self.interval_counter % self.cv_interval == 0:
             # send information to central visualizer
-            if self.p2p_state != "started":
-                self.visual_debugger()
+            self.visual_debugger()
 
     def terminate(self):
         pass
@@ -854,16 +853,16 @@ class BaseTopologyManager(ControllerModule):
         new_msg = {
             "type": "BaseTopologyManager",
             "uid": self.uid,
-            "p2p_state": self.p2p_state,
-            "successor": [],
-            "chord": [],
-            "on_demand": [],
-            "inbound": []
+            "ip4": self.ip4,
+            "state": self.p2p_state,
+            "links": {
+                "successor": [], "chord": [], "on_demand": [], "inbound": []
+            }
         }
 
         for con_type in ["successor", "chord", "on_demand", "inbound"]:
             for peer in self.links[con_type].keys():
                 if self.linked(peer):
-                    new_msg[con_type].append(peer)
+                    new_msg["links"][con_type].append(peer)
 
         self.registerCBT('CentralVisualizer', 'SEND_INFO', new_msg)

--- a/controller/modules/sample-gvpn-config.json
+++ b/controller/modules/sample-gvpn-config.json
@@ -50,7 +50,8 @@
         "enabled": true,
         "stat_server": "metrics.ipop-project.org",
         "stat_server_port": 8080,
-        "timer_interval": 200
+        "timer_interval": 200,
+        "dependencies": ["Logger"]
     },
         "CentralVisualizer": {
         "enabled": false,

--- a/controller/modules/sample-gvpn-config.json
+++ b/controller/modules/sample-gvpn-config.json
@@ -1,62 +1,63 @@
 {
-    "CFx": {
-        "xmpp_username": "",
-        "xmpp_password": "",
-        "xmpp_host": "",
-        "xmpp_port": 5222,
-        "tincan_logging": 0,
-        "vpn_type": "GroupVPN",
-        "ip4_mask": 16
-    },
-        "Logger": {
-        "controller_logging": "ERROR"
-    },
-        "TincanDispatcher": {
-        "dependencies": ["Logger"]
-    },
-        "TincanListener" : {
-        "socket_read_wait_time": 15,
-        "dependencies": ["Logger", "TincanDispatcher"]
-    },
-        "TincanSender": {
-        "switchmode": 0,
-        "dependencies": ["Logger"]
-    },
-        "BaseTopologyManager": {
-        "ip4": "172.31.0.100",
-        "sec": true,
-        "multihop": false,
-        "num_successors": 20,
-        "num_chords": 10,
-        "num_on_demand": 20,
-        "num_inbound": 50,
-        "ttl_link_initial": 60,
-        "ttl_link_pulse": 30,
-        "ttl_chord": 180,
-        "ttl_on_demand": 240,
-        "threshold_on_demand": 128,
-        "timer_interval": 1,
-        "interval_management": 15,
-        "use_central_visualizer": false,
-        "interval_central_visualizer": 5,
-        "num_pings": 5,
-        "interval_ping": 300,
-        "dependencies": ["Logger"]
-    },
-        "LinkManager": {
-        "dependencies": ["Logger"]
-    },
-        "StatReport": {
-        "enabled": true,
-        "stat_server": "metrics.ipop-project.org",
-        "stat_server_port": 8080,
-        "timer_interval": 200,
-        "dependencies": ["Logger"]
-    },
-        "CentralVisualizer": {
-        "enabled": false,
-        "central_visualizer_addr": "",
-        "central_visualizer_port": 51234,
-        "dependencies": ["Logger"]
-    }
+  "CFx": {
+    "xmpp_username": "",
+    "xmpp_password": "",
+    "xmpp_host": "",
+    "xmpp_port": 5222,
+    "tincan_logging": 0,
+    "vpn_type": "GroupVPN",
+    "ip4_mask": 16
+  },
+  "Logger": {
+    "controller_logging": "ERROR"
+  },
+  "TincanDispatcher": {
+    "dependencies": ["Logger"]
+  },
+  "TincanListener" : {
+    "socket_read_wait_time": 15,
+    "dependencies": ["Logger", "TincanDispatcher"]
+  },
+  "TincanSender": {
+    "switchmode": 0,
+    "dependencies": ["Logger"]
+  },
+  "BaseTopologyManager": {
+    "ip4": "172.31.0.100",
+    "sec": true,
+    "multihop": false,
+    "num_successors": 20,
+    "num_chords": 10,
+    "num_on_demand": 20,
+    "num_inbound": 50,
+    "ttl_link_initial": 60,
+    "ttl_link_pulse": 30,
+    "ttl_chord": 180,
+    "ttl_on_demand": 240,
+    "threshold_on_demand": 128,
+    "timer_interval": 1,
+    "interval_management": 15,
+    "use_central_visualizer": false,
+    "interval_central_visualizer": 5,
+    "num_pings": 5,
+    "interval_ping": 300,
+    "dependencies": ["Logger"]
+  },
+  "LinkManager": {
+    "dependencies": ["Logger"]
+  },
+  "StatReport": {
+    "enabled": true,
+    "stat_server": "metrics.ipop-project.org",
+    "stat_server_port": 8080,
+    "timer_interval": 200,
+    "dependencies": ["Logger"]
+  },
+  "CentralVisualizer": {
+    "enabled": false,
+    "name": "",
+    "central_visualizer_addr": "",
+    "central_visualizer_port": 51234,
+    "dependencies": ["Logger"]
+  }
 }

--- a/controller/modules/sample-svpn-config.json
+++ b/controller/modules/sample-svpn-config.json
@@ -1,55 +1,63 @@
 {
-    "CFx": {
-        "xmpp_username": "",
-        "xmpp_password": "",
-        "xmpp_host": "",
-        "xmpp_port": 5222,
-        "tincan_logging": 0,
-        "vpn_type": "SocialVPN",
-        "ip4_mask": 24
-    },
-        "Logger": {
-        "controller_logging": "ERROR"
-    },
-        "TincanDispatcher": {
-        "dependencies": ["Logger"]
-    },
-	    "TincanListener" : {
-        "socket_read_wait_time": 15,
-        "dependencies": ["Logger", "TincanDispatcher"]
-    },
-        "TincanSender": {
-        "dependencies": ["Logger"]
-    },
-        "Monitor": {
-        "trigger_con_wait_time": 120,
-        "dependencies": ["Logger"]
-    },
-        "BaseTopologyManager": {
-        "link_trimmer_wait_time": 30,
-        "on-demand_connection": false,
-        "on-demand_inactive_timeout": 600,
-        "multihop": false,
-        "sec": true,
-        "timer_interval": 15,
-        "dependencies": ["Logger"]
-    },
-        "LinkManager": {
-        "dependencies": ["Logger"]
-    },
-        "AddressMapper": {
-        "ip4": "172.31.0.100",
-        "dependencies": ["Logger"]
-    },
-        "Watchdog": {
-        "timer_interval": 10,
-        "dependencies": ["Logger"]
-    },
-        "StatReport": {
-        "enabled": true,
-        "stat_server": "metrics.ipop-project.org",
-        "stat_server_port": 8080,
-        "timer_interval": 200,
-        "dependencies": ["Logger"]
-    }
+  "CFx": {
+    "xmpp_username": "",
+    "xmpp_password": "",
+    "xmpp_host": "",
+    "xmpp_port": 5222,
+    "tincan_logging": 0,
+    "vpn_type": "SocialVPN",
+    "ip4_mask": 24
+  },
+  "Logger": {
+    "controller_logging": "ERROR"
+  },
+  "TincanDispatcher": {
+    "dependencies": ["Logger"]
+  },
+  "TincanListener" : {
+    "socket_read_wait_time": 15,
+    "dependencies": ["Logger", "TincanDispatcher"]
+  },
+  "TincanSender": {
+    "dependencies": ["Logger"]
+  },
+  "Monitor": {
+    "trigger_con_wait_time": 120,
+    "use_central_visualizer": false,
+    "dependencies": ["Logger"]
+  },
+  "BaseTopologyManager": {
+    "link_trimmer_wait_time": 30,
+    "on-demand_connection": false,
+    "on-demand_inactive_timeout": 600,
+    "multihop": false,
+    "sec": true,
+    "timer_interval": 15,
+    "dependencies": ["Logger"]
+  },
+  "LinkManager": {
+    "dependencies": ["Logger"]
+  },
+  "AddressMapper": {
+    "ip4": "172.31.0.100",
+    "dependencies": ["Logger"]
+  },
+  "Watchdog": {
+    "timer_interval": 10,
+    "dependencies": ["Logger"]
+  },
+  "StatReport": {
+    "enabled": true,
+    "stat_server": "metrics.ipop-project.org",
+    "stat_server_port": 8080,
+    "timer_interval": 200,
+    "dependencies": ["Logger"]
+  },
+  "CentralVisualizer": {
+    "enabled": false,
+    "name": "",
+    "central_visualizer_addr": "",
+    "central_visualizer_port": 51234,
+    "dependencies": ["Logger"]
+  }
 }

--- a/controller/modules/sample-svpn-config.json
+++ b/controller/modules/sample-svpn-config.json
@@ -49,6 +49,7 @@
         "enabled": true,
         "stat_server": "metrics.ipop-project.org",
         "stat_server_port": 8080,
-        "timer_interval": 200
+        "timer_interval": 200,
+        "dependencies": ["Logger"]
     }
 }


### PR DESCRIPTION
The `StatReport` module depends on the `Logger` module.

Updated the CentralVisualizer interface (with gvpn-BaseTopologyManager and svpn-Monitor changes) to allow generic communication to the visualizer.

Update sample configuration files.