### PR TITLE
python3 support & code cleanup

### DIFF
--- a/controller/Controller.py
+++ b/controller/Controller.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from framework.CFx import CFX
+from controller.framework.CFx import CFX
 
 
 def main():

--- a/controller/framework/CBT.py
+++ b/controller/framework/CBT.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import uuid
 
 
@@ -5,7 +6,7 @@ class CBT(object):
 
     def __init__(self, initiator='', recipient='', action='', data=''):
 
-        self.uid = uuid.uuid4() # Unique ID for CBTs
+        self.uid = uuid.uuid4() # Unique identifier for CBTs
         self.initiator = initiator
         self.recipient = recipient
         self.action = action

--- a/controller/framework/CFx.py
+++ b/controller/framework/CFx.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import os
 import sys
 import json

--- a/controller/framework/CFxHandle.py
+++ b/controller/framework/CFxHandle.py
@@ -13,7 +13,6 @@ else:
 class CFxHandle(object):
 
     def __init__(self, CFxObject):
-
         self.CMQueue = Queue.Queue()  # CBT queue
         self.CMInstance = None
         self.CMThread = None  # CM worker thread
@@ -24,117 +23,115 @@ class CFxHandle(object):
         self.terminateFlag = False
 
     def __getCBT(self):
-
-        cbt = self.CMQueue.get()  # Blocking call
+        cbt = self.CMQueue.get()  # blocking call
         return cbt
 
     def submitCBT(self, cbt):
-
-        # Submit CBT to the CFx
+        # submit CBT to the CFx
         self.__CFxObject.submitCBT(cbt)
 
     def createCBT(self, initiator='', recipient='', action='', data=''):
-
-        # Create and return a CBT with optional parameters
+        # create and return a CBT with optional parameters
         cbt = self.__CFxObject.createCBT(initiator, recipient, action, data)
         return cbt
 
     def freeCBT(self):
-
-        # Deallocate the CBT here
-        # Python automatic garbage collector handles it anyway
+        # deallocate CBT (use python's automatic garbage collector)
         pass
 
     def initialize(self):
-
-        # Intialize CM first
+        # intialize the CM
         self.CMInstance.initialize()
 
-        # Create worker thread, which is started by CFx
+        # create the worker thread, which is started by CFx
         self.CMThread = threading.Thread(target=self.__worker)
         self.CMThread.setDaemon(True)
 
-        # Check whether CM requires join() or not
-        #if(self.CMConfig['joinEnabled'] == 'True'):
+        # check whether CM requires join() or not
         self.joinEnabled = True
 
-        # Check if the CMConfig has timer_interval specified
+        # check if the CMConfig has timer_interval specified
         timer_enabled = False
 
         try:
             interval = int(self.CMConfig['timer_interval'])
             timer_enabled = True
         except ValueError:
-            logging.warning("Invalid timer configuration for " + key +
-                            ". Timer has been disabled for this module")
+            logging.warning("Invalid timer configuration for {0}"
+                        ". Timer has been disabled for this module".format(key))
         except KeyError:
             pass
 
-        if(timer_enabled):
-
-            # Create timer worker thread. CFx is responsible to start
-            # this thread
+        if timer_enabled:
+            # create the timer worker thread, which is started by CFx
             self.timer_thread = threading.Thread(target=self.__timer_worker,
                                                  args=(interval,))
             self.timer_thread.setDaemon(False)
 
     def __worker(self):
-
-        # Get CBT from local queue, and call processCBT() which
-        # is responsible for processing one CBT, given as a parameter
-
-        while(True):
-
+        # get CBT from the local queue and call processCBT() of the 
+        # CBT recipient and passing the CBT as an argument
+        while True:
             cbt = self.__getCBT()
 
-            # Break the loop if special terminate CBT is received
-            if(cbt.action == 'TERMINATE'):
+            # break on special termination CBT
+            if cbt.action == 'TERMINATE':
                 self.terminateFlag = True
                 module_name = self.CMInstance.__class__.__name__
-                logging.info(module_name+" exiting")
+                logging.info("{0} exiting".format(module_name))
                 self.CMInstance.terminate()
                 break
             else:
-
-                #XXX
-                self.CMInstance.processCBT(cbt)
-                '''
                 try:
                     self.CMInstance.processCBT(cbt)
                 except SystemExit:
                     sys.exit()
                 except:
-                    logCBT = self.createCBT(initiator=self.CMInstance.__class__.__name__,
-                                                                  recipient='Logger',
-                                                                  action='warning',
-                                                                  data=traceback.format_exc())
-                    self.submitCBT(logCBT)
-                '''
-    def __timer_worker(self, interval):
+                    logCBT = self.createCBT(
+                        initiator=self.CMInstance.__class__.__name__,
+                        recipient='Logger',
+                        action='warning',
+                        data="CBT exception:\n"\
+                             "    initiator {0}\n"\
+                             "    recipient {1}:\n"\
+                             "    action    {2}:\n"\
+                             "    data      {3}:\n"\
+                             "    traceback:\n{4}"\
+                             .format(cbt.initiator, cbt.recipient, cbt.action,
+                                    cbt.data, traceback.format_exc())
+                    )
 
-        # Call the timer_method of CMs every x seconds
-        # x is specified in config.json as timer_interval
+                    self.submitCBT(logCBT)
+
+    def __timer_worker(self, interval):
+        # call the timer_method of each CM every timer_interval seconds
         event = threading.Event()
 
-        while(True):
-            if(self.terminateFlag):
+        while True:
+            if self.terminateFlag:
                 break
             event.wait(interval)
 
-            #XXX
-            self.CMInstance.timer_method()
-            '''
             try:
                 self.CMInstance.timer_method()
             except SystemExit:
                 sys.exit()
             except:
-                logCBT = self.createCBT(initiator=self.CMInstance.__class__.__name__,
-                                                                recipient='Logger',
-                                                                action='warning',
-                                                                data=traceback.format_exc())
+                self.registerCBT('Logger', 'error', traceback.format_exc())
+
+                log = "timer_method exception:\n{0}".format(traceback.format_exc())
+                self.registerCBT('Logger', 'error', log)
+
+
+                logCBT = self.createCBT(
+                    initiator=self.CMInstance.__class__.__name__,
+                    recipient='Logger',
+                    action='warning',
+                    data="timer_method exception:\n{0}".format(traceback.format_exc())
+                )
                 self.submitCBT(logCBT)
-            '''
+
+
     def queryParam(self, ParamName=""):
         pv = self.__CFxObject.queryParam(ParamName)
         return pv

--- a/controller/framework/CFxHandle.py
+++ b/controller/framework/CFxHandle.py
@@ -1,8 +1,14 @@
 import sys
-import Queue
 import logging
 import threading
 import traceback
+
+py_ver = sys.version_info[0]
+
+if py_ver == 3:
+    import queue as Queue
+else:
+    import Queue
 
 class CFxHandle(object):
 
@@ -89,6 +95,10 @@ class CFxHandle(object):
                 self.CMInstance.terminate()
                 break
             else:
+
+                #XXX
+                self.CMInstance.processCBT(cbt)
+                '''
                 try:
                     self.CMInstance.processCBT(cbt)
                 except SystemExit:
@@ -99,7 +109,7 @@ class CFxHandle(object):
                                                                   action='warning',
                                                                   data=traceback.format_exc())
                     self.submitCBT(logCBT)
-
+                '''
     def __timer_worker(self, interval):
 
         # Call the timer_method of CMs every x seconds
@@ -110,6 +120,10 @@ class CFxHandle(object):
             if(self.terminateFlag):
                 break
             event.wait(interval)
+
+            #XXX
+            self.CMInstance.timer_method()
+            '''
             try:
                 self.CMInstance.timer_method()
             except SystemExit:
@@ -120,7 +134,7 @@ class CFxHandle(object):
                                                                 action='warning',
                                                                 data=traceback.format_exc())
                 self.submitCBT(logCBT)
-
+            '''
     def queryParam(self, ParamName=""):
         pv = self.__CFxObject.queryParam(ParamName)
         return pv

--- a/controller/framework/CFxHandle.py
+++ b/controller/framework/CFxHandle.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import sys
 import logging
 import threading

--- a/controller/framework/ControllerModule.py
+++ b/controller/framework/ControllerModule.py
@@ -1,20 +1,20 @@
-from abc import ABCMeta, abstractmethod  # Only Python 2.6 and above
+from abc import ABCMeta, abstractmethod
 
 
-"""
-Defining an abstract class which the controller
-modules will implement, forcing them to override
-all the abstract methods
-"""
-
-
+# abstract ControllerModule (CM) class
+# all CM implementations inherit the variables declared here
+# all CM implementations must override the abstract methods declared here
 class ControllerModule(object):
 
     __metaclass__ = ABCMeta
 
-    def __init__(self):
+    def __init__(self, CFxHandle, paramDict, ModuleName):
         self.pendingCBT = {}
         self.CBTMappings = {}
+
+        self.CFxHandle = CFxHandle
+        self.CMConfig = paramDict
+        self.ModuleName = ModuleName
 
     @abstractmethod
     def initialize(self):
@@ -32,19 +32,32 @@ class ControllerModule(object):
     def terminate(self):
         pass
 
-    # Check if the given cbt is a request sent by the current module
-    # If yes, returns the source CBT for which the request has been
-    # created, else return None
+    # returns the source CBT if the given CBT is a request CBT associated with
+    # the original CBT; returns None otherwise
     def checkMapping(self, cbt):
         for key in self.CBTMappings:
-            if(cbt.uid in self.CBTMappings[key]):
+            if cbt.uid in self.CBTMappings[key]:
                 return key
         return None
 
-    # For a given sourceCBT's uid, check if all requests are serviced
+    # tests if all request CBTs associated with the given source CBT have been
+    # serviced
     def allServicesCompleted(self, sourceCBT_uid):
         requested_services = self.CBTMappings[sourceCBT_uid]
         for service in requested_services:
-            if(service not in self.pendingCBT):
+            if service not in self.pendingCBT:
                 return False
         return True
+
+    # create and submit CBT mask method
+    def registerCBT(self, _recipient, _action, _data='', _uid=None):
+        cbt = self.CFxHandle.createCBT(
+            initiator = self.ModuleName,
+            recipient = _recipient,
+            action = _action,
+            data = _data
+        )
+        if _uid is not None:
+            cbt.uid = _uid
+        self.CFxHandle.submitCBT(cbt)
+        return cbt

--- a/controller/framework/ControllerModule.py
+++ b/controller/framework/ControllerModule.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from abc import ABCMeta, abstractmethod
 
 

--- a/controller/framework/fxlib.py
+++ b/controller/framework/fxlib.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import argparse
 import binascii
 import datetime

--- a/controller/framework/fxlib.py
+++ b/controller/framework/fxlib.py
@@ -1,5 +1,3 @@
-﻿#!/usr/bin/env python
-
 import argparse
 import binascii
 import datetime
@@ -23,9 +21,9 @@ import controller.framework.ipoplib as ipoplib
 ipopVerMjr = "16";
 ipopVerMnr = "01";
 ipopVerRev = "0";
-ipopVerRel = ipopVerMjr + "." + ipopVerMnr + "." + ipopVerRev
+ipopVerRel = "{0}.{1}.{2}".format(ipopVerMjr, ipopVerMnr, ipopVerRev)
 
-# Set default config values
+# set default config values
 CONFIG = {
     "CFx": {
         "ip4_mask": 24,
@@ -123,21 +121,3 @@ def load_peer_ip_config(ip_config):
         ip = peer_ip["ipv4"]
         IP_MAP[uid] = ip
         logging.debug("MAP %s -> %s" % (ip, uid))
-
-
-
-# # When proces killed or keyboard interrupted exit_handler runs then exit
-# def exit_handler(signum, frame):
-#     logging.info("Terminating Controller")
-#     if CONFIG["stat_report"]:
-#         if server != None:
-#             server.report()
-#         else:
-#             logging.debug("Controller socket is not created yet")
-#     sys.exit(0)
-
-# signal.signal(signal.SIGINT, exit_handler)
-# AFAIK, there is no way to catch SIGKILL
-# signal.signal(signal.SIGKILL, exit_handler)
-# signal.signal(signal.SIGQUIT, exit_handler)
-# signal.signal(signal.SIGTERM, exit_handler)

--- a/controller/framework/fxlib.py
+++ b/controller/framework/fxlib.py
@@ -15,10 +15,10 @@ import socket
 import struct
 import sys
 import time
-import urllib2
 
 from threading import Timer
 import controller.framework.ipoplib as ipoplib
+
 
 ipopVerMjr = "16";
 ipopVerMnr = "01";
@@ -72,7 +72,7 @@ def gen_ip6(uid, ip6=None):
     return ip6
 
 def gen_uid(ip4):
-    return hashlib.sha1(ip4).hexdigest()[:CONFIG["CFx"]["uid_size"]]
+    return hashlib.sha1(ip4.encode('utf-8')).hexdigest()[:CONFIG["CFx"]["uid_size"]]
 
 def make_call(sock, payload=None, **params):
     if socket.has_ipv6:
@@ -82,9 +82,9 @@ def make_call(sock, payload=None, **params):
         dest = (CONFIG["TincanSender"]["localhost"],
                 CONFIG["TincanSender"]["svpn_port"])
     if payload is None:
-        return sock.sendto(ipoplib.ipop_ver + ipoplib.tincan_control + json.dumps(params), dest)
+        return sock.sendto(ipoplib.ipop_ver + ipoplib.tincan_control + bytes(json.dumps(params).encode('utf-8')), dest)
     else:
-        return sock.sendto(ipoplib.ipop_ver + ipoplib.tincan_packet + payload, dest)
+        return sock.sendto(bytes((ipoplib.ipop_ver + ipoplib.tincan_packet + payload).encode('utf-8')), dest)
 
 def do_set_logging(sock, logging):
     return make_call(sock, m="set_logging", logging=logging)

--- a/controller/framework/ipoplib.py
+++ b/controller/framework/ipoplib.py
@@ -1,5 +1,3 @@
-﻿#!/usr/bin/env python
-
 import sys
 
 py_ver = sys.version_info[0]
@@ -83,16 +81,16 @@ def gen_ip4(uid, peer_map, ip4):
     except KeyError:
         pass
 
-    ips = set(peer_map.values()) #XXX itervalues
+    ips = set(peer_map.values())
     prefix, _ = ip4.rsplit(".", 1)
-    # We allocate to *.101 - *.254. This ensures a 3-digit suffix and avoids
-    # the broadcast address. *.100 is our IPv4 address.
+    # we allocate *.101 - *254 ensuring a 3-digit suffix and avoiding the
+    # broadcast address; *.100 is the IPv4 address of this node
     for i in range(101, 255):
         peer_map[uid] = "%s.%s" % (prefix, i)
         if peer_map[uid] not in ips:
             return peer_map[uid]
     del peer_map[uid]
-    raise OverflowError("Too many peers, out of IPv4 addresses")
+    raise OverflowError("too many peers, out of IPv4 addresses")
 
 def make_remote_call(sock, dest_addr, dest_port, m_type, payload, **params):
     dest = (dest_addr, dest_port)

--- a/controller/framework/ipoplib.py
+++ b/controller/framework/ipoplib.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import sys
 
 py_ver = sys.version_info[0]

--- a/controller/framework/ipoplib.py
+++ b/controller/framework/ipoplib.py
@@ -1,38 +1,81 @@
 ﻿#!/usr/bin/env python
 
-ipop_ver = "\x03"
-tincan_control = "\x01"
-tincan_packet = "\x02"
-icc_control = "\x03"
-icc_packet = "\x04"
-icc_mac_control = "\x00\x69\x70\x6f\x70\x03"
-icc_mac_packet = "\x00\x69\x70\x6f\x70\x04"
-icc_ethernet_padding = "\x00\x00\x00\x00\x00\x00\x00\x00"
+import sys
+
+py_ver = sys.version_info[0]
+
+ipop_ver = b'\x03'
+tincan_control = b'\x01'
+tincan_packet = b'\x02'
+icc_control = b'\x03'
+icc_packet = b'\x04'
+icc_mac_control = b'\x00\x69\x70\x6f\x70\x03'
+icc_mac_packet = b'\x00\x69\x70\x6f\x70\x04'
+icc_ethernet_padding = b'\x00\x00\x00\x00\x00\x00\x00\x00'
+
 
 def ip6_a2b(str_ip6):
-    return "".join(x.decode("hex") for x in str_ip6.split(':'))
+    if py_ver == 3:
+        return b''.join(int(x, 16).to_bytes(2, byteorder='big') for x in str_ip6.split(':'))
+    else:
+        return ''.join(x.decode("hex") for x in str_ip6.split(':'))
 
 def ip6_b2a(bin_ip6):
-    return "".join(bin_ip6[x:x+2].encode("hex") + ":" for x in range(0, 14, 2))\
-           + bin_ip6[14].encode("hex") + bin_ip6[15].encode("hex")
-
+    if py_ver == 3:
+        return ''.join("%04x" % int.from_bytes(bin_ip6[i:i+2], byteorder='big') + ':'\
+                for i in range(0, 16, 2))[:-1]
+    else:
+        return ''.join(bin_ip6[x:x+2].encode("hex") + ":" for x in range(0, 16, 2))[:-1]
 
 def ip4_a2b(str_ip4):
-    return "".join(chr(int(x)) for x in str_ip4.split('.'))
+    if py_ver == 3:
+        return b''.join(int(x, 10).to_bytes(1, byteorder='big') for x in str_ip4.split('.'))
+    else:
+        return ''.join(chr(int(x)) for x in str_ip4.split('.'))
 
 def ip4_b2a(bin_ip4):
-    return "".join(str(ord(bin_ip4[x])) + "." for x in range(0, 3)) \
-           + str(ord(bin_ip4[3]))
+    if py_ver == 3:
+        return ''.join(str(int.from_bytes(bin_ip4[i:i+1], byteorder='big')) + '.'\
+                for i in range(0, 4, 1))[:-1]
+    else:
+        return ''.join(str(ord(bin_ip4[x])) + "." for x in range(0, 4))[:-1]
 
 def mac_a2b(str_mac):
-    return "".join(x.decode("hex") for x in str_mac.split(':'))
+    if py_ver == 3:
+        return b''.join(int(x, 16).to_bytes(1, byteorder='big') for x in str_mac.split(':'))
+    else:
+        return ''.join(x.decode("hex") for x in str_mac.split(':'))
 
 def mac_b2a(bin_mac):
-    return "".join(bin_mac[x].encode("hex") + ":" for x in range(0, 5)) +\
-           bin_mac[5].encode("hex")
+    if py_ver == 3:
+        return ''.join("%02x" % int.from_bytes(bin_mac[i:i+1], byteorder='big') + ':'\
+                for i in range(0, 6, 1))[:-1]
+    else:
+        return ''.join(bin_mac[x].encode("hex") + ":" for x in range(0, 6))[:-1]
 
 def uid_a2b(str_uid):
-    return str_uid.decode("hex")
+    if py_ver == 3:
+        return int(str_uid, 16).to_bytes(20, byteorder='big')
+    else:
+        return str_uid.decode("hex")
+
+def uid_b2a(bin_uid):
+    if py_ver == 3:
+        return "%40x" % int.from_bytes(bin_uid, byteorder='big')
+    else:
+        return bin_uid.encode("hex")
+
+def hexstr2b(hexstr):
+    if py_ver == 3:
+        return b''.join(int(hexstr[i:i+2], 16).to_bytes(1, byteorder='big') for i in range(0, len(hexstr), 2))
+    else:
+        return hexstr.decode('hex')
+
+def b2hexstr(binary):
+    if py_ver == 3:
+        return ''.join("%02x" % int.from_bytes(binary[i:i+1], byteorder='big') for i in range(0, len(binary), 1))
+    else:
+        return binary.encode('hex')
 
 def gen_ip4(uid, peer_map, ip4):
     try:
@@ -40,7 +83,7 @@ def gen_ip4(uid, peer_map, ip4):
     except KeyError:
         pass
 
-    ips = set(peer_map.itervalues())
+    ips = set(peer_map.values()) #XXX itervalues
     prefix, _ = ip4.rsplit(".", 1)
     # We allocate to *.101 - *.254. This ensures a 3-digit suffix and avoids
     # the broadcast address. *.100 is our IPv4 address.

--- a/controller/modules/CentralVisualizer.py
+++ b/controller/modules/CentralVisualizer.py
@@ -5,33 +5,29 @@ from controller.framework.ControllerModule import ControllerModule
 
 class CentralVisualizer(ControllerModule):
 
-    def __init__(self, CFxHandle, paramDict):
-
-        super(CentralVisualizer, self).__init__()
-        self.CFxHandle = CFxHandle
-        self.CMConfig = paramDict
+    def __init__(self, CFxHandle, paramDict, ModuleName):
+        super(CentralVisualizer, self).__init__(CFxHandle, paramDict, ModuleName)
 
         self.vis_address = (
             self.CMConfig["central_visualizer_addr"],
-            self.CMConfig["central_visualizer_port"]
-        )
+            self.CMConfig["central_visualizer_port"])
 
     def initialize(self):
+        self.registerCBT('Logger', 'info', "{0} Loaded".format(self.ModuleName))
+
         self.vis_dbg_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
-        logCBT = self.CFxHandle.createCBT(initiator='CentralVisualizer',
-                                          recipient='Logger',
-                                          action='info',
-                                          data="CentralVisualizer Loaded")
-        self.CFxHandle.submitCBT(logCBT)
-
     def processCBT(self, cbt):
-        if(cbt.action == 'SEND_INFO'):
-
+        if cbt.action == 'SEND_INFO':
             cbt.data["name"] = self.CMConfig["name"]
 
             message = json.dumps(cbt.data).encode("utf8")
             self.vis_dbg_sock.sendto(message, self.vis_address)
+
+        else:
+            log = '{0}: unrecognized CBT {1} received from {2}'\
+                    .format(cbt.recipient, cbt.action, cbt.initiator)
+            self.registerCBT('Logger', 'warning', log)
 
     def timer_method(self):
         pass

--- a/controller/modules/CentralVisualizer.py
+++ b/controller/modules/CentralVisualizer.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import json
 import socket
 from controller.framework.ControllerModule import ControllerModule

--- a/controller/modules/LinkManager.py
+++ b/controller/modules/LinkManager.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from controller.framework.ControllerModule import ControllerModule
 
 

--- a/controller/modules/LinkManager.py
+++ b/controller/modules/LinkManager.py
@@ -3,63 +3,26 @@ from controller.framework.ControllerModule import ControllerModule
 
 class LinkManager(ControllerModule):
 
-    def __init__(self, CFxHandle, paramDict):
-
-        super(LinkManager, self).__init__()
-        self.CFxHandle = CFxHandle
-        self.CMConfig = paramDict
+    def __init__(self, CFxHandle, paramDict, ModuleName):
+        super(LinkManager, self).__init__(CFxHandle, paramDict, ModuleName)
 
     def initialize(self):
-
-        logCBT = self.CFxHandle.createCBT(initiator='LinkManager',
-                                          recipient='Logger',
-                                          action='info',
-                                          data="LinkManager Loaded")
-        self.CFxHandle.submitCBT(logCBT)
+        self.registerCBT('Logger', 'info', "{0} Loaded".format(self.ModuleName))
 
     def processCBT(self, cbt):
+        if cbt.action == "CREATE_LINK":
+            # cbt.data contains DO_CREATE_LINK arguments
+            self.registerCBT('TincanSender', 'DO_CREATE_LINK', cbt.data)
+            self.registerCBT('Logger', 'info', 'creating link with peer')
 
-        if(cbt.action == "CREATE_LINK"):
-
-            # cbt.data is a dict containing all the required
-            # paramters to create a link
-
-            TincanCBT = self.CFxHandle.createCBT(initiator='LinkManager',
-                                                 recipient='TincanSender',
-                                                 action='DO_CREATE_LINK',
-                                                 data=cbt.data)
-            self.CFxHandle.submitCBT(TincanCBT)
-
-            logCBT = self.CFxHandle.createCBT(initiator='LinkManager',
-                                              recipient='Logger',
-                                              action='info',
-                                              data="Creating Link with peer")
-            self.CFxHandle.submitCBT(logCBT)
-
-        elif(cbt.action == "TRIM_LINK"):
-
-            # cbt.data is the  UID of the peer node, whose link has
-            # to be trim
-            TincanCBT = self.CFxHandle.createCBT(initiator='LinkManager',
-                                                 recipient='TincanSender',
-                                                 action='DO_TRIM_LINK',
-                                                 data=cbt.data)
-            self.CFxHandle.submitCBT(TincanCBT)
-
-            logCBT = self.CFxHandle.createCBT(initiator='LinkManager',
-                                              recipient='Logger',
-                                              action='info',
-                                              data="Trimming Link "
-                                              "with peer " + cbt.data)
-            self.CFxHandle.submitCBT(logCBT)
+        elif cbt.action == "TRIM_LINK":
+            # cbt.data contains the UID of the peer
+            self.registerCBT('TincanSender', 'DO_TRIM_LINK', cbt.data)
 
         else:
-            logCBT = self.CFxHandle.createCBT(initiator='LinkManager',
-                                              recipient='Logger',
-                                              action='warning',
-                                              data="LinkManager: Invalid CBT "
-                                              "received from " + cbt.initiator)
-            self.CFxHandle.submitCBT(logCBT)
+            log = '{0}: unrecognized CBT {1} received from {2}'\
+                    .format(cbt.recipient, cbt.action, cbt.initiator)
+            self.registerCBT('Logger', 'warning', log)
 
     def timer_method(self):
         pass

--- a/controller/modules/Logger.py
+++ b/controller/modules/Logger.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import logging
 from controller.framework.ControllerModule import ControllerModule
 

--- a/controller/modules/Logger.py
+++ b/controller/modules/Logger.py
@@ -4,40 +4,36 @@ from controller.framework.ControllerModule import ControllerModule
 
 class Logger(ControllerModule):
 
-    def __init__(self, CFxHandle, paramDict):
-
-        super(Logger, self).__init__()
-        self.CFxHandle = CFxHandle
-        self.CMConfig = paramDict
+    def __init__(self, CFxHandle, paramDict, ModuleName):
+        super(Logger, self).__init__(CFxHandle, paramDict, ModuleName)
 
     def initialize(self):
-
         if "controller_logging" in self.CMConfig:
             level = getattr(logging, self.CMConfig["controller_logging"])
             logging.basicConfig(format='[%(asctime)s.%(msecs)03d] %(levelname)s:%(message)s',datefmt='%Y%m%d %H:%M:%S',level=level)
 
         logging.info("Logger Module Loaded")
 
-        # PKTDUMP mode is for more detailed than debug logging,
-        # especially for dump packet contents in hexadecimal to log
+        # PKTDUMP mode dumps packet information
         logging.addLevelName(5, "PKTDUMP")
         logging.PKTDUMP = 5
 
     def processCBT(self, cbt):
-
-        if(cbt.action == 'debug'):
+        if cbt.action == 'debug':
             logging.debug(cbt.data)
-        elif(cbt.action == 'info'):
+        elif cbt.action == 'info':
             logging.info(cbt.data)
-        elif(cbt.action == 'warning'):
+        elif cbt.action == 'warning':
             logging.warning(cbt.data)
-        elif(cbt.action == 'error'):
+        elif cbt.action == 'error':
             logging.error(cbt.data)
-        elif(cbt.action == "pktdump"):
+        elif cbt.action == "pktdump":
             self.pktdump(message=cbt.data.get('message'),
                          dump=cbt.data.get('dump'))
         else:
-            logging.warning("Unrecognized CBT from "+cbt.initiator)
+            log = '{0}: unrecognized CBT {1} received from {2}'\
+                    .format(cbt.recipient, cbt.action, cbt.initiator)
+            self.registerCBT('Logger', 'warning', log)
 
     def timer_method(self):
         pass

--- a/controller/modules/StatReport.py
+++ b/controller/modules/StatReport.py
@@ -1,14 +1,20 @@
 ﻿#!/usr/bin/env python
 
+import sys
 import datetime
 import hashlib
 import json
 import logging
-import urllib2
-
-import controller.framework.ipoplib as il
-#from controller.framework.CFxHandle import CFxHandle
+import controller.framework.ipoplib as ipoplib
 from controller.framework.ControllerModule import ControllerModule
+
+py_ver = sys.version_info[0]
+
+if py_ver == 3:
+    import urllib.request as urllib2
+else:
+    import urllib2
+
 
 class StatReport(ControllerModule):
 
@@ -41,12 +47,12 @@ class StatReport(ControllerModule):
         xmpp_host = self.CFxHandle.queryParam("xmpp_host")
         xmpp_username = self.CFxHandle.queryParam("xmpp_username")
         controller = self.CFxHandle.queryParam("vpn_type")
-        version = il.ipop_ver
+        version = ipoplib.ipop_ver
 
         data = json.dumps({
-                "xmpp_host" : hashlib.sha1(xmpp_host).hexdigest(),\
-                "uid": hashlib.sha1(uid).hexdigest(), "xmpp_username":\
-                hashlib.sha1(xmpp_username).hexdigest(),\
+                "xmpp_host" : hashlib.sha1(xmpp_host.encode('utf-8')).hexdigest(),\
+                "uid": hashlib.sha1(uid.encode('utf-8')).hexdigest(), "xmpp_username":\
+                hashlib.sha1(xmpp_username.encode('utf-8')).hexdigest(),\
                 "time": str(datetime.datetime.now()),\
                 "controller": controller,\
                 "version": ord(version)})
@@ -74,7 +80,3 @@ class StatReport(ControllerModule):
                                     action='warning',
                                     data="Statistics report failed to the stat-server ({0}).".format(url))
             self.CFxHandle.submitCBT(logCBT)
-
-
-
-

--- a/controller/modules/StatReport.py
+++ b/controller/modules/StatReport.py
@@ -1,5 +1,4 @@
 ﻿#!/usr/bin/env python
-
 import sys
 import datetime
 import hashlib

--- a/controller/modules/TincanListener.py
+++ b/controller/modules/TincanListener.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import select
 from threading import Thread
 from controller.framework.ControllerModule import ControllerModule

--- a/controller/modules/TincanListener.py
+++ b/controller/modules/TincanListener.py
@@ -5,27 +5,21 @@ from controller.framework.ControllerModule import ControllerModule
 
 class TincanListener(ControllerModule):
 
-    def __init__(self, sock_list, CFxHandle, paramDict):
+    def __init__(self, sock_list, CFxHandle, paramDict, ModuleName):
 
-        super(TincanListener, self).__init__()
-        self.CFxHandle = CFxHandle
-        self.CMConfig = paramDict
+        super(TincanListener, self).__init__(CFxHandle, paramDict, ModuleName)
+
         self.sock = sock_list[0]
         self.sock_svr = sock_list[1]
         self.sock_list = sock_list
 
     def initialize(self):
+        self.registerCBT('Logger', 'info', "{0} Loaded".format(self.ModuleName))
 
-        # Create a thread to listen to Tincan Notifications
+        # create a listener thread (listens to tincan notifications
         self.TincanListenerThread = Thread(target=self.__tincan_listener)
         self.TincanListenerThread.setDaemon(True)
         self.TincanListenerThread.start()
-
-        logCBT = self.CFxHandle.createCBT(initiator='TincanListener',
-                                          recipient='Logger',
-                                          action='info',
-                                          data="TincanListener Loaded")
-        self.CFxHandle.submitCBT(logCBT)
 
     def processCBT(self, cbt):
         pass
@@ -34,20 +28,14 @@ class TincanListener(ControllerModule):
         pass
 
     def __tincan_listener(self):
-
-        while(True):
+        while True:
             socks, _, _ = select.select(self.sock_list, [], [],
                                         self.CMConfig["socket_read_wait_time"])
 
             for sock in socks:
-                if(sock == self.sock or sock == self.sock_svr):
+                if sock == self.sock or sock == self.sock_svr:
                     data,addr = sock.recvfrom(self.CMConfig["buf_size"])
-                    cbt = self.CFxHandle.createCBT(initiator='TincanListener',
-                                                   recipient='Tincan'
-                                                   'Dispatcher',
-                                                   action='TINCAN_PKT',
-                                                   data=[data, addr])
-                    self.CFxHandle.submitCBT(cbt)
+                    self.registerCBT('TincanDispatcher', 'TINCAN_PKT', [data, addr])
 
     def terminate(self):
         pass

--- a/controller/modules/TincanSender.py
+++ b/controller/modules/TincanSender.py
@@ -74,7 +74,7 @@ class TincanSender(ControllerModule):
             self.do_send_icc_msg(self.sock, src_uid, dst_uid, icc_type, msg)
 
         elif(cbt.action == 'DO_INSERT_DATA_PACKET'):
-            self.send_packet(self.sock, cbt.data.decode("hex"))
+            self.send_packet(self.sock, ipoplib.hexstr2b(cbt.data))
 
         else:
             logCBT = self.CFxHandle.createCBT(initiator='TincanSender',
@@ -92,10 +92,10 @@ class TincanSender(ControllerModule):
             dest = (self.CMConfig["localhost"], self.CMConfig["svpn_port"])
 
         if icc_type == "control":
-            return sock.sendto(ipoplib.ipop_ver + ipoplib.icc_control + ipoplib.uid_a2b(src_uid) + ipoplib.uid_a2b(dst_uid) + ipoplib.icc_mac_control + ipoplib.icc_ethernet_padding + json.dumps(msg), dest)
+            return sock.sendto(ipoplib.ipop_ver + ipoplib.icc_control + ipoplib.uid_a2b(src_uid) + ipoplib.uid_a2b(dst_uid) + ipoplib.icc_mac_control + ipoplib.icc_ethernet_padding + bytes(json.dumps(msg).encode('utf-8')), dest)
 
         elif icc_type == "packet":
-            return sock.sendto(ipoplib.ipop_ver + ipoplib.icc_packet + ipoplib.uid_a2b(src_uid) + ipoplib.uid_a2b(dst_uid) + ipoplib.icc_mac_packet + ipoplib.icc_ethernet_padding + json.dumps(msg), dest)
+            return sock.sendto(ipoplib.ipop_ver + ipoplib.icc_packet + ipoplib.uid_a2b(src_uid) + ipoplib.uid_a2b(dst_uid) + ipoplib.icc_mac_packet + ipoplib.icc_ethernet_padding + bytes(json.dumps(msg).encode('utf-8')), dest)
 
     def do_create_link(self, sock, uid, fpr, overlay_id, sec,
                        cas, stun=None, turn=None):
@@ -137,11 +137,9 @@ class TincanSender(ControllerModule):
         else:
             dest = (self.CMConfig["localhost"], self.CMConfig["svpn_port"])
         if payload is None:
-            return sock.sendto(ipoplib.ipop_ver + ipoplib.tincan_control +
-                               json.dumps(params), dest)
+            return sock.sendto(ipoplib.ipop_ver + ipoplib.tincan_control + bytes(json.dumps(params).encode('utf-8')), dest)
         else:
-            return sock.sendto(ipoplib.ipop_ver + ipoplib.tincan_packet +
-                               payload, dest)
+            return sock.sendto(bytes((ipoplib.ipop_ver + ipoplib.tincan_packet + payload).encode('utf-8')), dest)
 
     def gen_ip6(self, uid, ip6=None):
         if ip6 is None:

--- a/controller/modules/TincanSender.py
+++ b/controller/modules/TincanSender.py
@@ -1,4 +1,5 @@
-﻿import json
+#!/usr/bin/env python
+import json
 import socket
 import random
 import controller.framework.ipoplib as ipoplib

--- a/controller/modules/gvpn/BaseTopologyManager.py
+++ b/controller/modules/gvpn/BaseTopologyManager.py
@@ -1,4 +1,5 @@
-﻿import sys
+﻿#!/usr/bin/env python
+import sys
 import time
 import math
 import json

--- a/controller/modules/svpn/AddressMapper.py
+++ b/controller/modules/svpn/AddressMapper.py
@@ -1,4 +1,5 @@
-﻿import controller.framework.ipoplib as ipoplib
+﻿#!/usr/bin/env python
+import controller.framework.ipoplib as ipoplib
 from controller.framework.ControllerModule import ControllerModule
 
 

--- a/controller/modules/svpn/BaseTopologyManager.py
+++ b/controller/modules/svpn/BaseTopologyManager.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import controller.framework.ipoplib as ipoplib
 from controller.framework.ControllerModule import ControllerModule
 

--- a/controller/modules/svpn/BaseTopologyManager.py
+++ b/controller/modules/svpn/BaseTopologyManager.py
@@ -4,251 +4,139 @@ from controller.framework.ControllerModule import ControllerModule
 
 class BaseTopologyManager(ControllerModule):
 
-    def __init__(self, CFxHandle, paramDict):
+    def __init__(self, CFxHandle, paramDict, ModuleName):
+        super(BaseTopologyManager, self).__init__(CFxHandle, paramDict, ModuleName)
 
-        super(BaseTopologyManager, self).__init__()
-        self.CFxHandle = CFxHandle
-        self.CMConfig = paramDict
         self.ipop_state = None
 
     def initialize(self):
-
-        logCBT = self.CFxHandle.createCBT(initiator='BaseTopologyManager',
-                                          recipient='Logger',
-                                          action='info',
-                                          data="BaseTopologyManager Loaded")
-        self.CFxHandle.submitCBT(logCBT)
+        self.registerCBT('Logger', 'info', "{0} Loaded".format(self.ModuleName))
 
     def processCBT(self, cbt):
-
-        # In case of a fresh CBT, request the required services
-        # from the other modules, by issuing CBTs. If no services
-        # from other modules required, process the CBT here only
-        if(not self.checkMapping(cbt)):
-            if(cbt.action == "TINCAN_MSG"):
+        # new CBTs request for services from other modules by issuing CBTs; if no
+        # services are required, the CBT is processed here only
+        if not self.checkMapping(cbt):
+            if cbt.action == "TINCAN_MSG":
                 msg = cbt.data
                 msg_type = msg.get("type", None)
 
-                # we ignore connection status notification for now
-                if msg_type == "con_stat":
-                    pass
-
-                elif msg_type == "con_req" or msg_type == "con_resp":
-                    stateCBT = self.CFxHandle.createCBT(initiator='Base'
-                                                        'TopologyManager',
-                                                        recipient='Watchdog',
-                                                        action='QUERY_IPOP'
-                                                        '_STATE',
-                                                        data="")
-                    self.CFxHandle.submitCBT(stateCBT)
+                if msg_type == "con_req" or msg_type == "con_resp":
+                    stateCBT = self.registerCBT('Watchdog', 'QUERY_IPOP_STATE')
                     self.CBTMappings[cbt.uid] = [stateCBT.uid]
 
-                    mapCBT = self.CFxHandle.createCBT(initiator='BaseTopology'
-                                                      'Manager',
-                                                      recipient='Address'
-                                                      'Mapper',
-                                                      action='RESOLVE',
-                                                      data=msg['uid'])
-                    self.CFxHandle.submitCBT(mapCBT)
+                    mapCBT = self.registerCBT('AddressMapper', 'RESOLVE', msg['uid'])
                     self.CBTMappings[cbt.uid].append(mapCBT.uid)
 
-                    ip_mapCBT = self.CFxHandle.createCBT(initiator='Base'
-                                                         'TopologyManager',
-                                                         recipient='Address'
-                                                         'Mapper',
-                                                         action='QUERY_IP_MAP',
-                                                         data="")
-                    self.CFxHandle.submitCBT(ip_mapCBT)
+                    ip_mapCBT = self.registerCBT('AddressMapper', 'QUERY_IP_MAP')
                     self.CBTMappings[cbt.uid].append(ip_mapCBT.uid)
 
-                    conn_stat_CBT = self.CFxHandle.createCBT(initiator='Base'
-                                                             'TopologyManager',
-                                                             recipient='Monitor',
-                                                             action='QUERY_'
-                                                             'CONN_STAT',
-                                                             data=msg['uid'])
-                    self.CFxHandle.submitCBT(conn_stat_CBT)
+                    conn_stat_CBT = self.registerCBT('Monitor', 'QUERY_CONN_STAT', msg['uid'])
                     self.CBTMappings[cbt.uid].append(conn_stat_CBT.uid)
 
-                    peer_list_CBT = self.CFxHandle.createCBT(initiator='Base'
-                                                             'TopologyManager',
-                                                             recipient='Monitor',
-                                                             action='QUERY_'
-                                                             'PEER_LIST',
-                                                             data='')
-                    self.CFxHandle.submitCBT(peer_list_CBT)
+                    peer_list_CBT = self.registerCBT('Monitor', 'QUERY_PEER_LIST')
                     self.CBTMappings[cbt.uid].append(peer_list_CBT.uid)
 
-                    # Add CBT to pendingCBT dictionary
                     self.pendingCBT[cbt.uid] = cbt
 
-                # Pass for now
-                elif msg_type == "send_msg":
-                    pass
-
-            elif(cbt.action == "QUERY_PEER_LIST_RESP"):
-
-                # cbt.data is a dict of peers
+            elif cbt.action == "QUERY_PEER_LIST_RESP":
+                # cbt.data contains a dict of peers
                 self.__link_trimmer(cbt.data)
 
             else:
-                logCBT = self.CFxHandle.createCBT(initiator='BaseTopology'
-                                                  'Manager',
-                                                  recipient='Logger',
-                                                  action='warning',
-                                                  data="BaseTopologyManager:"
-                                                  " Unrecognized CBT "
-                                                  "from " + cbt.initiator)
-                self.CFxHandle.submitCBT(logCBT)
+                log = '{0}: unrecognized CBT {1} received from {2}'\
+                        .format(cbt.recipient, cbt.action, cbt.initiator)
+                self.registerCBT('Logger', 'warning', log)
 
-        # Case when one of the requested service CBT comes back
-
+        # CBTs that required servicing by other modules are processed here
         else:
-            # Get the source CBT of this request
+            # get the source CBT of this request
             sourceCBT_uid = self.checkMapping(cbt)
             self.pendingCBT[cbt.uid] = cbt
-            # If all the other services of this sourceCBT are also completed,
-            # process CBT here. Else wait for other CBTs to arrive
-            if(self.allServicesCompleted(sourceCBT_uid)):
-                if(self.pendingCBT[sourceCBT_uid].action == 'TINCAN_MSG'):
+
+            # wait until all requested services are complete
+            if self.allServicesCompleted(sourceCBT_uid):
+                if self.pendingCBT[sourceCBT_uid].action == 'TINCAN_MSG':
                     msg = self.pendingCBT[sourceCBT_uid].data
                     msg_type = msg.get("type", None)
                     if msg_type == "con_req" or msg_type == "con_resp":
                         for key in self.CBTMappings[sourceCBT_uid]:
-                            if(self.pendingCBT[key].action ==
-                                    'QUERY_IPOP_STATE_RESP'):
+                            if self.pendingCBT[key].action == 'QUERY_IPOP_STATE_RESP':
                                 self.ipop_state = self.pendingCBT[key].data
-                            elif(self.pendingCBT[key].action ==
-                                    'RESOLVE_RESP'):
+                            elif self.pendingCBT[key].action == 'RESOLVE_RESP':
                                 ip4 = self.pendingCBT[key].data
-                            elif(self.pendingCBT[key].action ==
-                                    'QUERY_CONN_STAT_RESP'):
+                            elif self.pendingCBT[key].action == 'QUERY_CONN_STAT_RESP':
                                 conn_stat = self.pendingCBT[key].data
-                            elif(self.pendingCBT[key].action ==
-                                    'QUERY_PEER_LIST_RESP'):
+                            elif self.pendingCBT[key].action == 'QUERY_PEER_LIST_RESP':
                                 peer_list = self.pendingCBT[key].data
-                            elif(self.pendingCBT[key].action ==
-                                    'QUERY_IP_MAP_RESP'):
+                            elif self.pendingCBT[key].action == 'QUERY_IP_MAP_RESP':
                                 ip_map = self.pendingCBT[key].data
 
-                        logCBT = self.CFxHandle.createCBT(initiator='Base'
-                                                          'TopologyManager',
-                                                          recipient='Logger',
-                                                          action='info',
-                                                          data="Received"
-                                                          " connection request"
-                                                          "/response")
-                        self.CFxHandle.submitCBT(logCBT)
+                        # process the original CBT when all values have been received
+                        log = "received connection request/response"
+                        self.registerCBT('Logger', 'info', log)
 
                         if self.CMConfig["multihop"]:
                             conn_cnt = 0
-                            for k, v in peer_list.items(): #XXX iteritems
+                            for k, v in peer_list.items():
                                 if "fpr" in v and v["status"] == "online":
                                     conn_cnt += 1
                             if conn_cnt >= self.CMConfig["multihop_cl"]:
                                 return
-                        if self.check_collision(msg_type, msg["uid"],
-                                                conn_stat):
+                        if self.check_collision(msg_type, msg["uid"], conn_stat):
                             return
                         fpr_len = len(self.ipop_state["_fpr"])
                         fpr = msg["data"][:fpr_len]
                         cas = msg["data"][fpr_len + 1:]
                         ip4 = ipoplib.gen_ip4(msg["uid"],
-                                              ip_map,
-                                              self.ipop_state["_ip4"])
+                                ip_map,
+                                self.ipop_state["_ip4"])
+
                         self.create_connection(msg["uid"], fpr, 1,
-                                               self.CMConfig["sec"], cas, ip4)
+                                self.CMConfig["sec"], cas, ip4)
+
 
     def create_connection(self, uid, data, nid, sec, cas, ip4):
+        conn_dict = {'uid': uid, 'fpr': data, 'nid': nid, 'sec': sec, 'cas': cas}
+        self.registerCBT('LinkManager', 'CREATE_LINK', conn_dict)
 
-        conn_dict = {'uid': uid, 'fpr': data, 'nid': nid,
-                     'sec': sec, 'cas': cas}
-        createLinkCBT = self.CFxHandle.createCBT(initiator='BaseTopology'
-                                                 'Manager',
-                                                 recipient='LinkManager',
-                                                 action='CREATE_LINK',
-                                                 data=conn_dict)
-        self.CFxHandle.submitCBT(createLinkCBT)
+        cbtdata = {"uid": uid, "ip4": ip4}
+        self.registerCBT('TincanSender', 'DO_SET_REMOTE_IP', cbtdata)
 
-        cbtdata = {
-            "uid": uid,
-            "ip4": ip4,
-        }
-
-        TincanCBT = self.CFxHandle.createCBT(initiator='BaseTopologyManager',
-                                             recipient='TincanSender',
-                                             action='DO_SET_REMOTE_IP',
-                                             data=cbtdata)
-        self.CFxHandle.submitCBT(TincanCBT)
-
+    # TODO appears to always return False
     def check_collision(self, msg_type, uid, conn_stat):
-        if msg_type == "con_req" and \
-           conn_stat == "req_sent":
+        if msg_type == "con_req" and conn_stat == "req_sent":
             if uid > self.ipop_state["_uid"]:
-                trimCBT = self.CFxHandle.createCBT(initiator='Base'
-                                                   'TopologyManager',
-                                                   recipient='LinkManager',
-                                                   action='TRIM_LINK',
-                                                   data=uid)
-                self.CFxHandle.submitCBT(trimCBT)
-
-                conn_stat_pop_CBT = self.CFxHandle.createCBT(initiator='Base'
-                                                             'TopologyManager',
-                                                             recipient='Monitor',
-                                                             action='DELETE_'
-                                                             'CONN_STAT',
-                                                             data=uid)
-                self.CFxHandle.submitCBT(conn_stat_pop_CBT)
+                self.registerCBT('LinkManager', 'TRIM_LINK', uid)
+                self.registerCBT('Monitor', 'DELETE_CONN_STAT', uid)
             return False
         elif msg_type == "con_resp":
-            conn_stat_CBT = self.CFxHandle.createCBT(initiator='Base'
-                                                     'TopologyManager',
-                                                     recipient='Monitor',
-                                                     action='STORE_CONN_STAT',
-                                                     data={
-                                                          'uid': uid,
-                                                          'status': "resp_recv"
-                                                           })
-            self.CFxHandle.submitCBT(conn_stat_CBT)
+            cbtdata = {
+                'uid': uid,
+                'status': "resp_recv"
+            }
+
+            self.registerCBT('Monitor', 'STORE_CONN_STAT', cbtdata)
             return False
         else:
             return True
 
     def __link_trimmer(self, peer_list):
-        for k, v in peer_list.items(): #XXX iteritems
-            # Trim TinCan link if the peer is offline
+        for k, v in peer_list.items():
+            # trim the links of offline peers
             if "fpr" in v and v["status"] == "offline":
                 if v["last_time"] > self.CMConfig["link_trimmer_wait_time"]:
-                    trimCBT = self.CFxHandle.createCBT(initiator='Base'
-                                                       'TopologyManager',
-                                                       recipient='LinkManager',
-                                                       action='TRIM_LINK',
-                                                       data=k)
-                    self.CFxHandle.submitCBT(trimCBT)
+                    self.registerCBT('LinkManager', 'TRIM_LINK', k)
 
             if self.CMConfig["multihop"]:
                 connection_count = 0
-                for k, v in peer_list.items(): #XXX iteritems
+                for k, v in peer_list.items():
                     if "fpr" in v and v["status"] == "online":
                         connection_count += 1
                         if connection_count > self.CMConfig["multihop_cl"]:
-                            trimCBT = self.CFxHandle.createCBT(initiator='Base'
-                                                               'Topology'
-                                                               'Manager',
-                                                               recipient='Link'
-                                                               'Manager',
-                                                               action='TRIM_'
-                                                               'LINK',
-                                                               data=k)
-                            self.CFxHandle.submitCBT(trimCBT)
+                            self.registerCBT('LinkManager', 'TRIM_LINK', k)
 
     def timer_method(self):
-        peersCBT = self.CFxHandle.createCBT(initiator='BaseTopology'
-                                            'Manager',
-                                            recipient='Monitor',
-                                            action='QUERY_PEER_LIST',
-                                            data='')
-        self.CFxHandle.submitCBT(peersCBT)
+        self.registerCBT('Monitor', 'QUERY_PEER_LIST')
 
     def terminate(self):
         pass

--- a/controller/modules/svpn/BaseTopologyManager.py
+++ b/controller/modules/svpn/BaseTopologyManager.py
@@ -142,7 +142,7 @@ class BaseTopologyManager(ControllerModule):
 
                         if self.CMConfig["multihop"]:
                             conn_cnt = 0
-                            for k, v in peer_list.iteritems():
+                            for k, v in peer_list.items(): #XXX iteritems
                                 if "fpr" in v and v["status"] == "online":
                                     conn_cnt += 1
                             if conn_cnt >= self.CMConfig["multihop_cl"]:
@@ -215,7 +215,7 @@ class BaseTopologyManager(ControllerModule):
             return True
 
     def __link_trimmer(self, peer_list):
-        for k, v in peer_list.iteritems():
+        for k, v in peer_list.items(): #XXX iteritems
             # Trim TinCan link if the peer is offline
             if "fpr" in v and v["status"] == "offline":
                 if v["last_time"] > self.CMConfig["link_trimmer_wait_time"]:
@@ -228,7 +228,7 @@ class BaseTopologyManager(ControllerModule):
 
             if self.CMConfig["multihop"]:
                 connection_count = 0
-                for k, v in peer_list.iteritems():
+                for k, v in peer_list.items(): #XXX iteritems
                     if "fpr" in v and v["status"] == "online":
                         connection_count += 1
                         if connection_count > self.CMConfig["multihop_cl"]:

--- a/controller/modules/svpn/Monitor.py
+++ b/controller/modules/svpn/Monitor.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import time
 import controller.framework.ipoplib as ipoplib
 from controller.framework.ControllerModule import ControllerModule

--- a/controller/modules/svpn/Monitor.py
+++ b/controller/modules/svpn/Monitor.py
@@ -193,7 +193,7 @@ class Monitor(ControllerModule):
             "uid": self.ipop_state["_uid"],
             "ip4": self.ipop_state["_ip4"],
             "state": "connected",
-            "links": self.peers.keys()
+            "links": list(self.peers.keys())
         }
 
         TincanCBT = self.CFxHandle.createCBT(initiator='Monitor',

--- a/controller/modules/svpn/Monitor.py
+++ b/controller/modules/svpn/Monitor.py
@@ -5,11 +5,8 @@ from controller.framework.ControllerModule import ControllerModule
 
 class Monitor(ControllerModule):
 
-    def __init__(self, CFxHandle, paramDict):
-
-        super(Monitor, self).__init__()
-        self.CFxHandle = CFxHandle
-        self.CMConfig = paramDict
+    def __init__(self, CFxHandle, paramDict, ModuleName):
+        super(Monitor, self).__init__(CFxHandle, paramDict, ModuleName)
 
         self.use_visualizer = False
         if 'use_central_visualizer' in self.CMConfig:
@@ -24,143 +21,74 @@ class Monitor(ControllerModule):
         self.ipop_state = None
 
     def initialize(self):
-
-        logCBT = self.CFxHandle.createCBT(initiator='Monitor',
-                                          recipient='Logger',
-                                          action='info',
-                                          data="Monitor Loaded")
-        self.CFxHandle.submitCBT(logCBT)
+        self.registerCBT('Logger', 'info', "{0} Loaded".format(self.ModuleName))
 
     def processCBT(self, cbt):
-
-        # In case of a fresh CBT, request the required services
-        # from the other modules, by issuing CBTs. If no services
-        # from other modules required, process the CBT here only
-
-        if(not self.checkMapping(cbt)):
-
-            if(cbt.action == 'PEER_STATE'):
-
-                # Storing peer state requires ipop_state, which
-                # is requested by sending a CBT to Watchdog
-                stateCBT = self.CFxHandle.createCBT(initiator='Monitor',
-                                                    recipient='Watchdog',
-                                                    action='QUERY_IPOP_STATE',
-                                                    data="")
-                self.CFxHandle.submitCBT(stateCBT)
-
-                # Maintain a mapping of the source CBT and issued CBTs
+        # new CBTs request for services from other modules by issuing CBTs; if no
+        # services are required, the CBT is processed here only
+        if not self.checkMapping(cbt):
+            if cbt.action == 'PEER_STATE':
+                stateCBT = self.registerCBT('Watchdog', 'QUERY_IPOP_STATE')
                 self.CBTMappings[cbt.uid] = [stateCBT.uid]
-
-                # Put this CBT in pendingCBT dict, since it hasn't been
-                # processed yet
                 self.pendingCBT[cbt.uid] = cbt
 
-            elif(cbt.action == 'QUERY_PEER_STATE'):
+            elif cbt.action == 'QUERY_PEER_STATE':
+                self.registerCBT(cbt.initiator, 'QUERY_PEER_STATE_RESP', \
+                        self.peers.get(cbt.data), cbt.uid)
 
-                # Respond to a CM, requesting state of a particular peer
+            elif cbt.action == 'QUERY_PEER_LIST':
+                self.registerCBT(cbt.initiator, 'QUERY_PEER_LIST_RESP', \
+                        self.peers, cbt.uid)
 
-                peer_uid = cbt.data
-                cbt.action = 'QUERY_PEER_STATE_RESP'
-                cbt.initiator, cbt.recipient = cbt.recipient, cbt.initiator
-                cbt.data = self.peers.get(peer_uid)
-                self.CFxHandle.submitCBT(cbt)
 
-            elif(cbt.action == 'QUERY_PEER_LIST'):
+            elif cbt.action == 'QUERY_CONN_STAT':
+                self.registerCBT(cbt.initiator, 'QUERY_CONN_STAT_RESP', \
+                        self.conn_stat.get(cbt.data), cbt.uid)
 
-                # Respond to a CM requesting state of a particular peer
-
-                cbt.action = 'QUERY_PEER_LIST_RESP'
-                cbt.initiator, cbt.recipient = cbt.recipient, cbt.initiator
-                cbt.data = self.peers
-                self.CFxHandle.submitCBT(cbt)
-
-            elif(cbt.action == 'QUERY_CONN_STAT'):
-
-                # Respond to a CM requesting conn_stat of a particular peer
-                uid = cbt.data
-                cbt.action = 'QUERY_CONN_STAT_RESP'
-                cbt.initiator, cbt.recipient = cbt.recipient, cbt.initiator
-                cbt.data = self.conn_stat.get(uid)
-                self.CFxHandle.submitCBT(cbt)
-
-            elif(cbt.action == 'DELETE_CONN_STAT'):
-
-                # Delete conn_stat of a given peer on request from another CM
+            elif cbt.action == 'DELETE_CONN_STAT':
                 uid = cbt.data
                 self.conn_stat.pop(uid, None)
 
-            elif(cbt.action == 'STORE_CONN_STAT'):
-
-                # Store conn_stat of a given peer
+            elif cbt.action == 'STORE_CONN_STAT':
                 try:
                     self.conn_stat[cbt.data['uid']] = cbt.data['status']
                 except KeyError:
-                    logCBT = self.CFxHandle.createCBT(initiator='Monitor',
-                                                      recipient='Logger',
-                                                      action='warning',
-                                                      data="Invalid "
-                                                      "STORE_CONN_STAT"
-                                                      " Configuration"
-                                                      " from " + cbt.initiator)
-                    self.CFxHandle.submitCBT(logCBT)
+                    log = "invalid STORE_CONN_STAT configuration"
+                    self.registerCBT('Logger', 'warning', log)
 
-            elif(cbt.action == 'QUERY_IDLE_PEER_STATE'):
+            elif cbt.action == 'QUERY_IDLE_PEER_STATE':
+                self.registerCBT(cbt.initiator, 'QUERY_IDLE_PEER_STATE_RESP', \
+                        self.idle_peers.get(cbt.data), cbt.uid)
 
-                # Respond to a CM requesting idle peer state
-                idle_peer_uid = cbt.data
-                cbt.action = 'QUERY_IDLE_PEER_STATE_RESP'
-                cbt.initiator, cbt.recipient = cbt.recipient, cbt.initiator
-                cbt.data = self.idle_peers.get(idle_peer_uid)
-                self.CFxHandle.submitCBT(cbt)
-
-            elif(cbt.action == 'STORE_IDLE_PEER_STATE'):
-
-                # Store state of a given idle peer
+            elif cbt.action == 'STORE_IDLE_PEER_STATE':
+                # store state of a given idle peer
                 try:
-                    # cbt.data is a dict with uid and idle_peer_state keys
-                    self.idle_peers[cbt.data['uid']] = \
-                                    cbt.data['idle_peer_state']
+                # cbt.data contains a {'uid': <uid>, 'idle_peer_state': <peer_state>} mapping
+                    self.idle_peers[cbt.data['uid']] = cbt.data['idle_peer_state']
                 except KeyError:
 
-                    logCBT = self.CFxHandle.createCBT(initiator='Monitor',
-                                                      recipient='Logger',
-                                                      action='warning',
-                                                      data="Invalid "
-                                                      "STORE_IDLE_PEER_STATE"
-                                                      " Configuration")
-                    self.CFxHandle.submitCBT(logCBT)
+                    log = "invalid STORE_IDLE_PEER_STATE configuration"
+                    self.registerCBT('Logger', 'warning', log)
 
             else:
-                logCBT = self.CFxHandle.createCBT(initiator='Monitor',
-                                                  recipient='Logger',
-                                                  action='error',
-                                                  data="Monitor: Unrecognized "
-                                                  "CBT from: " + cbt.initiator)
-                self.CFxHandle.submitCBT(logCBT)
+                log = '{0}: unrecognized CBT {1} received from {2}'\
+                        .format(cbt.recipient, cbt.action, cbt.initiator)
+                self.registerCBT('Logger', 'warning', log)
 
-        # Case when one of the requested service CBT comes back
+        # CBTs that required servicing by other modules are processed here
         else:
-
-            # Get the source CBT of this response CBT
+            # get the source CBT of this request
             sourceCBT_uid = self.checkMapping(cbt)
             self.pendingCBT[cbt.uid] = cbt
 
-            # If all the other services of this sourceCBT are also completed,
-            # process CBT here. Else wait for other CBTs to arrive
-            if(self.allServicesCompleted(sourceCBT_uid)):
-                if(self.pendingCBT[sourceCBT_uid].action ==
-                        'PEER_STATE'):
-
-                    # Retrieve values from response CBTs
+            # wait until all requested services are complete
+            if self.allServicesCompleted(sourceCBT_uid):
+                if self.pendingCBT[sourceCBT_uid].action == 'PEER_STATE':
                     for key in self.CBTMappings[sourceCBT_uid]:
-                        if(self.pendingCBT[key].action ==
-                           'QUERY_IPOP_STATE_RESP'):
+                        if self.pendingCBT[key].action == 'QUERY_IPOP_STATE_RESP':
                             self.ipop_state = self.pendingCBT[key].data
 
-                    # Process the source CBT, once all the required variables
-                    # are extracted from the response CBTs
-
+                    # process the original CBT when all values have been received
                     msg = self.pendingCBT[sourceCBT_uid].data
                     msg_type = msg.get("type", None)
 
@@ -176,7 +104,7 @@ class Monitor(ControllerModule):
                                 del self.peers_ip6[self.peers[uid]["ip6"]]
                         self.peers[uid] = msg
                         self.trigger_conn_request(msg)
-                        if msg["status"] == "offline" or "stats" not in msg:
+                        if msg["status"] == "offline" or ("stats" not in msg):
                             self.peers[msg["uid"]] = msg
                             self.trigger_conn_request(msg)
 
@@ -187,7 +115,6 @@ class Monitor(ControllerModule):
     # visual debugger
     #   send information to the central visualizer
     def visual_debugger(self):
-
         new_msg = {
             "type": "Monitor",
             "uid": self.ipop_state["_uid"],
@@ -196,29 +123,21 @@ class Monitor(ControllerModule):
             "links": list(self.peers.keys())
         }
 
-        TincanCBT = self.CFxHandle.createCBT(initiator='Monitor',
-                                             recipient='CentralVisualizer',
-                                             action='SEND_INFO',
-                                             data=new_msg)
-        self.CFxHandle.submitCBT(TincanCBT)
+        self.registerCBT('CentralVisualizer', 'SEND_INFO', new_msg)
 
     def trigger_conn_request(self, peer):
-        if "fpr" not in peer and peer["xmpp_time"] < \
-                self.CMConfig["trigger_con_wait_time"]:
+        if ("fpr" not in peer) and peer["xmpp_time"] < \
+            self.CMConfig["trigger_con_wait_time"]:
             self.conn_stat[peer["uid"]] = "req_sent"
 
-            cbtData = {
+            cbtdata = {
                 "method": "con_req",
                 "overlay_id": 1,
                 "uid": peer["uid"],
                 "data": self.ipop_state["_fpr"]
             }
 
-            TincanCBT = self.CFxHandle.createCBT(initiator='Monitor',
-                                                 recipient='TincanSender',
-                                                 action='DO_SEND_MSG',
-                                                 data=cbtData)
-            self.CFxHandle.submitCBT(TincanCBT)
+            self.registerCBT('TincanSender', 'DO_SEND_MSG', cbtdata)
 
     def terminate(self):
         pass

--- a/controller/modules/svpn/TincanDispatcher.py
+++ b/controller/modules/svpn/TincanDispatcher.py
@@ -8,33 +8,24 @@ py_ver = sys.version_info[0]
 
 class TincanDispatcher(ControllerModule):
 
-    def __init__(self, CFxHandle, paramDict):
-
-        super(TincanDispatcher, self).__init__()
-        self.CFxHandle = CFxHandle
-        self.CMConfig = paramDict
+    def __init__(self, CFxHandle, paramDict, ModuleName):
+        super(TincanDispatcher, self).__init__(CFxHandle, paramDict, ModuleName)
 
     def initialize(self):
-
-        logCBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
-                                          recipient='Logger',
-                                          action='info',
-                                          data="TincanDispatcher Loaded")
-        self.CFxHandle.submitCBT(logCBT)
+        self.registerCBT('Logger', 'info', "{0} Loaded".format(self.ModuleName))
 
     def processCBT(self, cbt):
-
         data = cbt.data[0]
         addr = cbt.data[1]
 
-        # Data format:
-        # ---------------------------------------------------------------
-        # | offset(byte) |                                              |
-        # ---------------------------------------------------------------
-        # |      0       | ipop version                                 |
-        # |      1       | message type                                 |
-        # |      2       | Payload (JSON formatted control message)     |
-        # ---------------------------------------------------------------
+        # packet format (data):
+        # +---------------+-----------------------------------------------+
+        # | offset (byte) |                                               |
+        # +---------------+-----------------------------------------------+
+        # |      0        | ipop version                                  |
+        # |      1        | message type                                  |
+        # |      2        | payload (JSON formatted control message)      |
+        # +---------------+-----------------------------------------------+
 
         if py_ver == 3:
             pkt_ver = data[0].to_bytes(1, byteorder='big')
@@ -44,20 +35,13 @@ class TincanDispatcher(ControllerModule):
             pkt_type = data[1]
 
         if pkt_ver != ipoplib.ipop_ver:
+            log = "ipop version mismatch: tincan: {0} controller: {1}"\
+                        .format(hex(data[0]), ipoplib.ipop_ver)
+            self.registerCBT('Logger', 'error', log)
+#            sys.exit() #TODO
 
-            logCBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
-                                              recipient='Logger',
-                                              action='error',
-                                              data="ipop version mismatch:"
-                                              "tincan:{0} controller: {1}"
-                                              .format(hex(data[0]), ipoplib.ipop_ver))
-            self.CFxHandle.submitCBT(logCBT)
-#            sys.exit() #XXX
-
-        if "TINCAN_PKT" == cbt.action:
-
+        if cbt.action == "TINCAN_PKT":
             if pkt_type == ipoplib.tincan_control:
-
                 msg = json.loads(data[2:].decode('utf-8'))
                 logCBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
                                                   recipient='Logger',
@@ -68,93 +52,54 @@ class TincanDispatcher(ControllerModule):
                 msg_type = msg.get("type", None)
 
                 if msg_type == "echo_request":
-
                     # Reply to the echo_request
-
                     echo_data = {
                        'm_type': ipoplib.tincan_control,
                        'dest_addr': addr[0],
                        'dest_port': addr[1]
                     }
 
-                    echoCBT = self.CFxHandle.createCBT(initiator='Tincan'
-                                                       'Dispatcher',
-                                                       recipient='TincanSender',
-                                                       action='ECHO_REPLY',
-                                                       data=echo_data)
-                    self.CFxHandle.submitCBT(echoCBT)
+                    self.registerCBT('TincanSender', 'ECHO_REPLY', echo_data)
 
                 elif msg_type == "local_state":
-
-                    # Send CBT to Watchdog to store ipop_state
-
-                    CBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
-                                                   recipient='Watchdog',
-                                                   action='STORE_IPOP_STATE',
-                                                   data=msg)
-                    self.CFxHandle.submitCBT(CBT)
+                    self.registerCBT('Watchdog', 'STORE_IPOP_STATE', msg)
 
                 elif msg_type == "peer_state":
+                    self.registerCBT('Monitor', 'PEER_STATE', msg)
 
-                    # Send CBT to Monitor to store peer state
+                elif msg_type in ["con_req", "con_resp"]:
+                    self.registerCBT('BaseTopologyManager', 'TINCAN_MSG', msg)
 
-                    CBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
-                                                   recipient='Monitor',
-                                                   action='PEER_STATE',
-                                                   data=msg)
-                    self.CFxHandle.submitCBT(CBT)
+            # tincan packets destined to a node in which a tincan connection
+            # has not yet been established are forwarded to the controller
+            # +---------------+-------------------------------------------+
+            # | offset (byte) |                                           |
+            # +---------------+-------------------------------------------+
+            # |      0        | ipop version                              |
+            # |      1        | message type                              |
+            # |      2        | source uid                                |
+            # |     22        | destination uid                           |
+            # |     42        | Payload (Ethernet frame)                  |
+            # +---------------+-------------------------------------------+
 
-                elif (msg_type == "con_stat" or msg_type == "con_req" or
-                      msg_type == "con_resp" or msg_type == "send_msg"):
-
-                    CBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
-                                                   recipient='BaseTopologyManager',
-                                                   action='TINCAN_MSG',
-                                                   data=msg)
-                    self.CFxHandle.submitCBT(CBT)
-
-            #  If a packet that is destined to yet no p2p connection
-            #  established node, the packet as a whole is forwarded to
-            #  controller
-            # |-------------------------------------------------------------|
-            # | offset(byte) |                                              |
-            # |-------------------------------------------------------------|
-            # |      0       | ipop version                                 |
-            # |      1       | message type                                 |
-            # |      2       | source uid                                   |
-            # |     22       | destination uid                              |
-            # |     42       | Payload (Ethernet frame)                     |
-            # |-------------------------------------------------------------|
-
-            # Pass for now
             elif pkt_type == ipoplib.tincan_packet:
-
                 pass
 
             elif pkt_type == ipoplib.icc_control:
-
                 pass
 
             elif pkt_type == ipoplib.icc_packet:
-
                 pass
 
             else:
+                log = "Unrecognized message received from Tincan {0}".format(data)
+                self.registerCBT('Logger', 'error', log)
+#                sys.exit() #TODO
 
-                logCBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
-                                                  recipient='Logger',
-                                                  action='error',
-                                                  data="Tincan: "
-                                                  "Unrecognized message "
-                                                  "received from Tincan")
-                self.CFxHandle.submitCBT(logCBT)
-
-                logCBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
-                                                  recipient='Logger',
-                                                  action='debug',
-                                                  data="{0}".format(data[0:]))
-                self.CFxHandle.submitCBT(logCBT)
-#                sys.exit() #XXX
+        else:
+            log = '{0}: unrecognized CBT {1} received from {2}'\
+                    .format(cbt.recipient, cbt.action, cbt.initiator)
+            self.registerCBT('Logger', 'warning', log)
 
     def timer_method(self):
         pass

--- a/controller/modules/svpn/TincanDispatcher.py
+++ b/controller/modules/svpn/TincanDispatcher.py
@@ -3,6 +3,9 @@ import sys
 from controller.framework.ControllerModule import ControllerModule
 import controller.framework.ipoplib as ipoplib
 
+py_ver = sys.version_info[0]
+
+
 class TincanDispatcher(ControllerModule):
 
     def __init__(self, CFxHandle, paramDict):
@@ -33,109 +36,125 @@ class TincanDispatcher(ControllerModule):
         # |      2       | Payload (JSON formatted control message)     |
         # ---------------------------------------------------------------
 
-        if data[0] != ipoplib.ipop_ver:
-
-            logCBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
-                                              recipient='Logger',
-                                              action='debug',
-                                              data="ipop version mismatch:"
-                                              "tincan:{0} controller: {1}"
-                                              .format(data[0].encode("hex"),
-                                                      ipoplib.ipop_ver.encode("hex")))
-            self.CFxHandle.submitCBT(logCBT)
-            sys.exit()
-
-        if data[1] == ipoplib.tincan_control:
-
-            msg = json.loads(data[2:])
-            logCBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
-                                              recipient='Logger',
-                                              action='debug',
-                                              data="recv {0} {1}"
-                                              .format(addr, data[2:]))
-            self.CFxHandle.submitCBT(logCBT)
-            msg_type = msg.get("type", None)
-
-            if msg_type == "echo_request":
-
-                # Reply to the echo_request
-
-                echo_data = {
-                   'm_type': ipoplib.tincan_control,
-                   'dest_addr': addr[0],
-                   'dest_port': addr[1]
-                }
-
-                echoCBT = self.CFxHandle.createCBT(initiator='Tincan'
-                                                   'Dispatcher',
-                                                   recipient='TincanSender',
-                                                   action='ECHO_REPLY',
-                                                   data=echo_data)
-                self.CFxHandle.submitCBT(echoCBT)
-
-            elif msg_type == "local_state":
-
-                # Send CBT to Watchdog to store ipop_state
-
-                CBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
-                                               recipient='Watchdog',
-                                               action='STORE_IPOP_STATE',
-                                               data=msg)
-                self.CFxHandle.submitCBT(CBT)
-
-            elif msg_type == "peer_state":
-
-                # Send CBT to Monitor to store peer state
-
-                CBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
-                                               recipient='Monitor',
-                                               action='PEER_STATE',
-                                               data=msg)
-                self.CFxHandle.submitCBT(CBT)
-
-            elif (msg_type == "con_stat" or msg_type == "con_req" or
-                  msg_type == "con_resp" or msg_type == "send_msg"):
-
-                CBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
-                                               recipient='BaseTopologyManager',
-                                               action='TINCAN_MSG',
-                                               data=msg)
-                self.CFxHandle.submitCBT(CBT)
-
-        #  If a packet that is destined to yet no p2p connection
-        #  established node, the packet as a whole is forwarded to
-        #  controller
-        # |-------------------------------------------------------------|
-        # | offset(byte) |                                              |
-        # |-------------------------------------------------------------|
-        # |      0       | ipop version                                 |
-        # |      1       | message type                                 |
-        # |      2       | source uid                                   |
-        # |     22       | destination uid                              |
-        # |     42       | Payload (Ethernet frame)                     |
-        # |-------------------------------------------------------------|
-
-        # Pass for now
-        elif data[1] == ipoplib.tincan_packet:
-            pass
-
+        if py_ver == 3:
+            pkt_ver = data[0].to_bytes(1, byteorder='big')
+            pkt_type = data[1].to_bytes(1, byteorder='big')
         else:
+            pkt_ver = data[0]
+            pkt_type = data[1]
+
+        if pkt_ver != ipoplib.ipop_ver:
 
             logCBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
                                               recipient='Logger',
                                               action='error',
-                                              data="Tincan: "
-                                              "Unrecognized message "
-                                              "received from Tincan")
+                                              data="ipop version mismatch:"
+                                              "tincan:{0} controller: {1}"
+                                              .format(hex(data[0]), ipoplib.ipop_ver))
             self.CFxHandle.submitCBT(logCBT)
+#            sys.exit() #XXX
 
-            logCBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
-                                              recipient='Logger',
-                                              action='debug',
-                                              data="{0}".format(data[0:].
-                                                                encode("hex")))
-            self.CFxHandle.submitCBT(logCBT)
-            sys.exit()
+        if "TINCAN_PKT" == cbt.action:
+
+            if pkt_type == ipoplib.tincan_control:
+
+                msg = json.loads(data[2:].decode('utf-8'))
+                logCBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
+                                                  recipient='Logger',
+                                                  action='debug',
+                                                  data="recv {0} {1}"
+                                                  .format(addr, data[2:]))
+                self.CFxHandle.submitCBT(logCBT)
+                msg_type = msg.get("type", None)
+
+                if msg_type == "echo_request":
+
+                    # Reply to the echo_request
+
+                    echo_data = {
+                       'm_type': ipoplib.tincan_control,
+                       'dest_addr': addr[0],
+                       'dest_port': addr[1]
+                    }
+
+                    echoCBT = self.CFxHandle.createCBT(initiator='Tincan'
+                                                       'Dispatcher',
+                                                       recipient='TincanSender',
+                                                       action='ECHO_REPLY',
+                                                       data=echo_data)
+                    self.CFxHandle.submitCBT(echoCBT)
+
+                elif msg_type == "local_state":
+
+                    # Send CBT to Watchdog to store ipop_state
+
+                    CBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
+                                                   recipient='Watchdog',
+                                                   action='STORE_IPOP_STATE',
+                                                   data=msg)
+                    self.CFxHandle.submitCBT(CBT)
+
+                elif msg_type == "peer_state":
+
+                    # Send CBT to Monitor to store peer state
+
+                    CBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
+                                                   recipient='Monitor',
+                                                   action='PEER_STATE',
+                                                   data=msg)
+                    self.CFxHandle.submitCBT(CBT)
+
+                elif (msg_type == "con_stat" or msg_type == "con_req" or
+                      msg_type == "con_resp" or msg_type == "send_msg"):
+
+                    CBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
+                                                   recipient='BaseTopologyManager',
+                                                   action='TINCAN_MSG',
+                                                   data=msg)
+                    self.CFxHandle.submitCBT(CBT)
+
+            #  If a packet that is destined to yet no p2p connection
+            #  established node, the packet as a whole is forwarded to
+            #  controller
+            # |-------------------------------------------------------------|
+            # | offset(byte) |                                              |
+            # |-------------------------------------------------------------|
+            # |      0       | ipop version                                 |
+            # |      1       | message type                                 |
+            # |      2       | source uid                                   |
+            # |     22       | destination uid                              |
+            # |     42       | Payload (Ethernet frame)                     |
+            # |-------------------------------------------------------------|
+
+            # Pass for now
+            elif pkt_type == ipoplib.tincan_packet:
+
+                pass
+
+            elif pkt_type == ipoplib.icc_control:
+
+                pass
+
+            elif pkt_type == ipoplib.icc_packet:
+
+                pass
+
+            else:
+
+                logCBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
+                                                  recipient='Logger',
+                                                  action='error',
+                                                  data="Tincan: "
+                                                  "Unrecognized message "
+                                                  "received from Tincan")
+                self.CFxHandle.submitCBT(logCBT)
+
+                logCBT = self.CFxHandle.createCBT(initiator='TincanDispatcher',
+                                                  recipient='Logger',
+                                                  action='debug',
+                                                  data="{0}".format(data[0:]))
+                self.CFxHandle.submitCBT(logCBT)
+#                sys.exit() #XXX
 
     def timer_method(self):
         pass

--- a/controller/modules/svpn/TincanDispatcher.py
+++ b/controller/modules/svpn/TincanDispatcher.py
@@ -1,4 +1,5 @@
-﻿import json
+#!/usr/bin/env python
+import json
 import sys
 from controller.framework.ControllerModule import ControllerModule
 import controller.framework.ipoplib as ipoplib

--- a/controller/modules/svpn/Watchdog.py
+++ b/controller/modules/svpn/Watchdog.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from controller.framework.ControllerModule import ControllerModule
 
 

--- a/controller/modules/svpn/Watchdog.py
+++ b/controller/modules/svpn/Watchdog.py
@@ -3,55 +3,30 @@ from controller.framework.ControllerModule import ControllerModule
 
 class Watchdog(ControllerModule):
 
-    def __init__(self, CFxHandle, paramDict):
+    def __init__(self, CFxHandle, paramDict, ModuleName):
+        super(Watchdog, self).__init__(CFxHandle, paramDict, ModuleName)
 
-        super(Watchdog, self).__init__()
-        self.CFxHandle = CFxHandle
-        self.CMConfig = paramDict
         self.ipop_state = None
 
     def initialize(self):
-
-        logCBT = self.CFxHandle.createCBT(initiator='Watchdog',
-                                          recipient='Logger',
-                                          action='info',
-                                          data="Watchdog Loaded")
-        self.CFxHandle.submitCBT(logCBT)
+        self.registerCBT('Logger', 'info', "{0} Loaded".format(self.ModuleName))
 
     def processCBT(self, cbt):
-
-        if(cbt.action == 'STORE_IPOP_STATE'):
-
-            # cbt.data contains the state of local node
+        if cbt.action == 'STORE_IPOP_STATE':
+            # cbt.data contains the local state
             msg = cbt.data
             self.ipop_state = msg
 
-        elif(cbt.action == 'QUERY_IPOP_STATE'):
-
-            cbt.action = 'QUERY_IPOP_STATE_RESP'
-            cbt.data = self.ipop_state
-            cbt.initiator, cbt.recipient = cbt.recipient, cbt.initiator
-
-            # Submit the CBT back to the initiator
-            # cbt.data contains ipop_state
-            self.CFxHandle.submitCBT(cbt)
+        elif cbt.action == 'QUERY_IPOP_STATE':
+            self.registerCBT(cbt.initiator, 'QUERY_IPOP_STATE_RESP', self.ipop_state, cbt.uid)
 
         else:
-
-            logCBT = self.CFxHandle.createCBT(initiator='Watchdog',
-                                              recipient='Logger',
-                                              action='error',
-                                              data="Watchdog: Unrecognized CBT"
-                                              "from: " + cbt.initiator)
-            self.CFxHandle.submitCBT(logCBT)
+            log = '{0}: unrecognized CBT {1} received from {2}'\
+                    .format(cbt.recipient, cbt.action, cbt.initiator)
+            self.registerCBT('Logger', 'warning', log)
 
     def timer_method(self):
-
-        TincanCBT = self.CFxHandle.createCBT(initiator='Watchdog',
-                                             recipient='TincanSender',
-                                             action='DO_GET_STATE',
-                                             data='')
-        self.CFxHandle.submitCBT(TincanCBT)
+        self.registerCBT('TincanSender', 'DO_GET_STATE')
 
     def terminate(self):
         pass


### PR DESCRIPTION
Summary of changes:

+ commit [302beb68c42e17796bbe8bec1b51a729d7e11b87]
	- add python3 support [https://github.com/ipop-project/ipop-project.github.io/issues/3]
		- the controller works with python2 and python3; a network may even use mixed python versions
	- restore "con_stat" notification handling
		- resolves an issue where the GroupVPN BaseTopologyManager would forward packets to nodes in which a tincan connection is not yet established
		- fixes a dangerous loop
	- generic fixes

+ commit [bcde6f77fe73b1840f8b3f851f1786df5d0403fb]
	- add registerCBT method to the ControllerModule abstract class
		- reduces code duplication significantly
		- simplifies CBT handling
	- other code cleanup
		- make the style of everything consistent

All changes have been tested on GroupVPN and SocialVPN, python2 and python3 using scale-test.